### PR TITLE
Add user to columbia substudy on registration.

### DIFF
--- a/src/components/registration/Registration.tsx
+++ b/src/components/registration/Registration.tsx
@@ -79,6 +79,7 @@ export const Registration: React.FunctionComponent<RegistrationProps> = ({
       phone: state.phone.value ? makePhone(state.phone.value) : undefined,
       clientData: {},
       study: STUDY_ID,
+      substudyIds: ["columbia"],
     }
     let loginType: LoginType = 'EMAIL'
     const endPoint = {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -49,7 +49,8 @@ export interface LoggedInUserData extends UserData {
 }
 
 export interface RegistrationData extends UserData {
-  study: string
+  study: string,
+  substudyIds: string[]
 }
 
 export interface Response<T> {


### PR DESCRIPTION
This allows us later to associate researchers with Columbia, and the only people they will see through our API are people who enrolled through Columbia.