### PR TITLE
Switch from use of study to the use of appId.

### DIFF
--- a/src/components/login/Login.tsx
+++ b/src/components/login/Login.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import {
+  APP_ID,
   EmailSigninParams,
   LoggedInUserData,
   SignInData,
@@ -37,7 +38,6 @@ export interface OwnLoginProps {
 
 export type LoginProps = OwnLoginProps & RouteComponentProps
 
-const STUDY_ID = 'czi-coronavirus'
 const EMAIL_SIGN_IN_TRIGGER_ENDPOINT = '/v3/auth/email'
 const PHONE_SIGN_IN_TRIGGER_ENDPOINT = '/v3/auth/phone'
 const EMAIL_SIGN_IN_ENDPOINT = '/v3/auth/email/signIn'
@@ -81,7 +81,7 @@ export const Login: React.FunctionComponent<LoginProps> = ({
     const signInWithEmail = async (email: string, token: string) => {
       setIsLoading(true)
       const postData = {
-        study: STUDY_ID,
+        appId: APP_ID,
         email: email,
         token: token,
       }
@@ -129,12 +129,12 @@ export const Login: React.FunctionComponent<LoginProps> = ({
     setLoginType(_loginType)
     if (_loginType === 'PHONE') {
       postData = {
-        study: STUDY_ID,
+        appId: APP_ID,
         phone: makePhone(phoneOrEmail),
       } as SignInDataPhone
     } else {
       postData = {
-        study: STUDY_ID,
+        appId: APP_ID,
         email: email,
       } as SignInDataEmail
     }

--- a/src/components/login/SignInWithCode.tsx
+++ b/src/components/login/SignInWithCode.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 
-import { STUDY_ID, ENDPOINT, LoginType } from '../../types/types'
+import { APP_ID, ENDPOINT, LoginType } from '../../types/types'
 import { callEndpoint, makePhone } from '../../helpers/utility'
 import Alert from '@material-ui/lab/Alert/Alert'
 import Button from '@material-ui/core/Button/Button'
@@ -27,7 +27,7 @@ export const SignInWithCode: React.FunctionComponent<SignInWithCodeProps> = ({
     clickEvent.preventDefault()
 
     const postData = {
-      study: STUDY_ID,
+      appId: APP_ID,
       phone: makePhone(phoneOrEmail),
       token: code,
     }

--- a/src/components/registration/Registration.tsx
+++ b/src/components/registration/Registration.tsx
@@ -3,7 +3,7 @@ import BlueSeparator from '../static/BlueSeparator'
 
 import useForm from '../useForm'
 import {
-  STUDY_ID,
+  APP_ID,
   ENDPOINT,
   RegistrationData,
   LoginType,
@@ -96,7 +96,7 @@ export const Registration: React.FunctionComponent<RegistrationProps> = ({
       email: state.email.value,
       phone: state.phone.value ? makePhone(state.phone.value) : undefined,
       clientData: {},
-      study: STUDY_ID,
+      appId: APP_ID,
       substudyIds: ['columbia'],
     }
     let loginType: LoginType = 'EMAIL'

--- a/src/helpers/utility.ts
+++ b/src/helpers/utility.ts
@@ -5,7 +5,7 @@ import {
   LoggedInUserData,
   SignInDataEmail,
   SignInDataPhone,
-  STUDY_ID,
+  APP_ID,
   LoginType,
   StringDictionary,
   SESSION_NAME,
@@ -112,12 +112,12 @@ export const sendSignInRequest = async (
   // setLoginType(_loginType)
   if (loginType === 'PHONE') {
     postData = {
-      study: STUDY_ID,
+      appId: APP_ID,
       phone: makePhone(phoneOrEmail),
     } as SignInDataPhone
   } else {
     postData = {
-      study: STUDY_ID,
+      appId: APP_ID,
       email: phoneOrEmail,
     } as SignInDataEmail
   }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,6 +1,6 @@
 import { EmailFormFields } from 'react-mailchimp-subscribe'
 
-export const STUDY_ID = 'czi-coronavirus'
+export const APP_ID = 'czi-coronavirus'
 
 export const SESSION_NAME = 'bridge-session-ny-strong'
 export const ENDPOINT = 'https://webservices.sagebridge.org'
@@ -62,7 +62,7 @@ export interface LoggedInUserData extends UserData {
 }
 
 export interface RegistrationData {
-  study: string
+  appId: string
   substudyIds: string[]
 
   email?: string
@@ -78,7 +78,7 @@ export interface Response<T> {
 }
 
 export type SignInData = {
-  study: string
+  appId: string
 }
 export interface SignInDataPhone extends SignInData {
   phone: {


### PR DESCRIPTION
We're in the process of removing "study" from the API because it needs to re-appear in v2 of the product as a different concept. I couldn't run the tests due to a failure in the test rig.