### PR TITLE
Add Home Kit Paper Instruction Page

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "react-dom": "^16.13.1",
     "react-geocode": "^0.2.1",
     "react-i18next": "^11.5.0",
-    "react-iframe": "^1.8.0",
     "react-jsonschema-form": "^1.8.1",
     "react-mailchimp-subscribe": "^2.1.0",
     "react-pdf": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-dom": "^16.13.1",
     "react-geocode": "^0.2.1",
     "react-i18next": "^11.5.0",
+    "react-iframe": "^1.8.0",
     "react-jsonschema-form": "^1.8.1",
     "react-mailchimp-subscribe": "^2.1.0",
     "react-pdf": "^4.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ import ConsentEHR from './components/consent/ConsentEHR'
 import Team from './components/static/Team'
 import Contact from './components/static/Contact'
 import FAQs from './components/static/FAQs'
+import TestKitInformationScreen from "./components/static/TestKitInformationScreen"
 import { TopNav } from './components/widgets/TopNav'
 import { UserService } from './services/user.service'
 import AcountSettings from './components/AccountSettings'
@@ -498,7 +499,9 @@ function App() {
                         <ResultDashboard token={token || ''} />,
                       )}
                     </ConsentedRoute>
-
+                    <Route path="/testkit">
+                      <TestKitInformationScreen />
+                    </Route>
                     <Route path="/faqs">
                       <FAQs />
                     </Route>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,7 +31,7 @@ import ConsentEHR from './components/consent/ConsentEHR'
 import Team from './components/static/Team'
 import Contact from './components/static/Contact'
 import FAQs from './components/static/FAQs'
-import TestKitInformationScreen from "./components/static/TestKitInformationScreen"
+import TestKitInformationScreen from './components/static/TestKitInformationScreen'
 import { TopNav } from './components/widgets/TopNav'
 import { UserService } from './services/user.service'
 import AcountSettings from './components/AccountSettings'
@@ -232,7 +232,6 @@ function App() {
     }
   }, [token])
 
-
   function PrivateRoute({ children, ...rest }: any) {
     return (
       <Route
@@ -352,9 +351,8 @@ function App() {
 
   const TOGGLES = {
     [TOGGLE_NAMES.RESULTS_VIDEO]: true,
-    [TOGGLE_NAMES.SPANISH]: true
+    [TOGGLE_NAMES.SPANISH]: true,
   }
-
   return (
     <FeaturesProvider value={TOGGLES}>
       <ThemeProvider theme={theme}>
@@ -375,9 +373,10 @@ function App() {
                   logoutCallbackFn={() =>
                     setUserSession(undefined, '', false, [])
                   }
+                  showTopNavigator={currentLocation !== '/testkit'}
                 >
                   {/* A <Switch> looks through its children <Route>s and
-        renders the first one that matches the current URL. */}{' '}
+         renders the first one that matches the current URL. */}{' '}
                   <Switch>
                     <Route
                       exact={true}

--- a/src/assets/locales/en/translation.json
+++ b/src/assets/locales/en/translation.json
@@ -393,7 +393,7 @@
       "surveysDoneTitle": "Thank you for completing the surveys!",
       "surveysDoneText": "<0>You now qualify for the antibody test waitlist!</0><0>To receive a gift card, you will need to be invited to an antibody test and provide a biosample.</0><0>We cannot guarantee testing invites for all participants at this time.</0><0>Please note that at-home test kits won’t be available until after December 2020.</0>",
       "selectedHomeTestText": "<0>Mailing Address for Home Kit</0><1>Should you be selected, we will be mailing the kit to this address below. Please edit if necessary before submitting your survey. </1>",
-      
+
       "selectedTestText": "<0>If you are selected to receive an antibody test, you will receive an email. </0>",
       "selectedNoTestTitle": "Thank you for your contribution to the COVID Recovery Corps Study!",
       "selectedNoTestText": "<0>As we learn more, we will provide updates on the results of the study in newsletters, online presentations, and community meetings.</0>",
@@ -406,7 +406,6 @@
       "cancelledText": "If you would like to re-schedule a lab appointment, please call 212-305-5700 or email: <0>COVIDRecoveryCorps@cumc.columbia.edu</0>. ",
 
       "addressUdateLink": "<0>Please update your address under </0> <1>Contact Information</1>"
-
     }
   },
   "footer": {
@@ -439,7 +438,6 @@
     "text3": "I am able to provide consent for myself",
     "text4": "I think I’ve had COVID-19",
     "text5a": "I live in the United States"
-   
   },
   "faqs": {
     "title": "FAQs",
@@ -725,5 +723,8 @@
     "title": "Your test kit is on its way!",
     "text1": "<0>Thank you for registering for the COVID Recovery Corps study to understand how the body responds to and recovers from COVID-19 infection. </0> <0> We have sent out your at-home test kit. Your blood sample will check whether your body has produced antibodies to fight the COVID-19 infection. </0><0> Please collect the blood sample and return the kit as soon as possible. Antibodies disappear over time, and we want to test for the antibodies while they are still in your system. </0><0> As a token of our appreciation, all participants who complete all of the surveys and provide at-home sample will receive a $20 gift card. </0><0> Collecting your samples should take less than 10 minutes. </0>",
     "cta": "Track my test kit"
+  },
+  "testKitInstructionPage": {
+    "instructionHeader": "Blood Sample Collection Instructions"
   }
 }

--- a/src/assets/locales/es/translation.json
+++ b/src/assets/locales/es/translation.json
@@ -402,7 +402,6 @@
       "missedText": "Si desea reprogramar una cita de laboratorio, llame al 212-305-5700 o envíe un correo electrónico: <0>COVIDRecoveryCorps@cumc.columbia.edu</0>. ",
       "cancelledTitle": "Su cita de laboratorio ha sido cancelada.",
       "cancelledText": "Si desea reprogramar una cita de laboratorio, llame al 212-305-5700 o envíe un correo electrónico: <0>COVIDRecoveryCorps@cumc.columbia.edu</0>. "
-  
     }
   },
   "footer": {
@@ -720,5 +719,8 @@
     "title": "Your test kit is on its way!",
     "text1": "<0>Thank you for registering for the COVID Recovery Corps study to understand how the body responds to and recovers from COVID-19 infection. </0> <0> We have sent out your at-home test kit. Your blood sample will check whether your body has produced antibodies to fight the COVID-19 infection. </0><0> Please collect the blood sample and return the kit as soon as possible. Antibodies disappear over time, and we want to test for the antibodies while they are still in your system. </0><0> As a token of our appreciation, all participants who complete all of the surveys and provide at-home sample will receive a $20 gift card. </0><0> Collecting your samples should take less than 10 minutes. </0>",
     "cta": "Track my test kit"
+  },
+  "testKitInstructionPage": {
+    "instructionHeader": "Instrucciones para la recolección de muestras de sangre"
   }
 }

--- a/src/components/static/TestKitInformationScreen.tsx
+++ b/src/components/static/TestKitInformationScreen.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react'
-import Iframe from 'react-iframe'
 import { makeStyles } from '@material-ui/core'
 import { NavLink } from 'react-router-dom'
 import { ReactComponent as CovidRecoveryCorpsLogo } from '../../assets/CovidRecoveryCorpsLogo.svg'
+import i18n from '../../i18n'
 
 const useStyles = makeStyles(theme => ({
   container: {
@@ -11,6 +11,7 @@ const useStyles = makeStyles(theme => ({
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
+    minWidth: '250px',
   },
   languageRow: {
     display: 'flex',
@@ -18,12 +19,14 @@ const useStyles = makeStyles(theme => ({
     justifyContent: 'space-between',
     color: 'black',
     width: '170px',
-    marginTop: '-15px',
   },
-  languageText: {
+  languageButton: {
     color: 'black',
     cursor: 'pointer',
     fontSize: '15px',
+    outline: 'none',
+    border: 'none',
+    backgroundColor: 'Transparent',
   },
   selectedLanguage: {
     fontWeight: 'bold',
@@ -31,6 +34,8 @@ const useStyles = makeStyles(theme => ({
   },
   videoContainer: {
     marginTop: '30px',
+    maxWidth: '900px',
+    maxHeight: '550px',
   },
   topBanner: {
     height: '92px',
@@ -40,22 +45,25 @@ const useStyles = makeStyles(theme => ({
     paddingTop: '15px',
     paddingLeft: '25px',
   },
+  header: {
+    textAlign: 'center',
+    marginBottom: '10px',
+    marginLeft: '5px',
+    marginRight: '5px',
+  },
 }))
 
 const TestKitInformationScreen: React.FC<{}> = props => {
-  const [englishIsSelected, setEnglishSelected] = useState<boolean>(true)
+  const [language, setLanguage] = useState<string>(i18n.language)
   const classes = useStyles()
-  const engishTextClasses = [classes.languageText]
-  const spanishTextClasses = [classes.languageText]
-  englishIsSelected
-    ? engishTextClasses.push(classes.selectedLanguage)
-    : spanishTextClasses.push(classes.selectedLanguage)
 
-  const handleLanguagePressed = (pressedLanguage: String) => {
-    if (pressedLanguage === 'ENGLISH' && !englishIsSelected) {
-      setEnglishSelected(true)
-    } else if (pressedLanguage === 'SPANISH' && englishIsSelected) {
-      setEnglishSelected(false)
+  const changeLanguage = (pressedLanguage: string) => {
+    if (pressedLanguage !== language) {
+      const newLanguage = i18n.language === 'es' ? 'en' : 'es'
+      window.localStorage.setItem('appUILang', newLanguage)
+
+      i18n.changeLanguage(newLanguage)
+      setLanguage(newLanguage)
     }
   }
 
@@ -66,27 +74,34 @@ const TestKitInformationScreen: React.FC<{}> = props => {
           <CovidRecoveryCorpsLogo />
         </NavLink>
       </div>
-
-      <h2>Blood Sample Collection Instructions</h2>
+      <h2 className={classes.header}>{`${
+        language === 'en'
+          ? 'Blood Sample Collection Instructions'
+          : 'Instrucciones para la recolección de muestras de sangre'
+      }`}</h2>
       <div className={classes.languageRow}>
-        <div
-          className={engishTextClasses.join(' ')}
-          onClick={() => handleLanguagePressed('ENGLISH')}
+        <button
+          className={`${classes.languageButton} ${
+            language === 'en' ? classes.selectedLanguage : null
+          }`}
+          onClick={() => changeLanguage('en')}
         >
           English
-        </div>
-        <div
-          className={spanishTextClasses.join(' ')}
-          onClick={() => handleLanguagePressed('SPANISH')}
+        </button>
+        <button
+          className={`${classes.languageButton} ${
+            language === 'en' ? null : classes.selectedLanguage
+          }`}
+          onClick={() => changeLanguage('es')}
         >
           en español
-        </div>
+        </button>
       </div>
-      <Iframe
-        width="900px"
-        height="550px"
-        url={
-          englishIsSelected
+      <iframe
+        width="100%"
+        height="60%"
+        src={
+          language === 'en'
             ? 'https://www.youtube.com/embed/--MX5u9a12Y?autoplay=1'
             : 'https://www.youtube.com/embed/bM6MoVTAegQ?autoplay=1'
         }

--- a/src/components/static/TestKitInformationScreen.tsx
+++ b/src/components/static/TestKitInformationScreen.tsx
@@ -1,13 +1,13 @@
 import React, { useState } from 'react'
 import Iframe from 'react-iframe'
 import { makeStyles } from '@material-ui/core'
-
-interface Props {}
+import { NavLink } from 'react-router-dom'
+import { ReactComponent as CovidRecoveryCorpsLogo } from '../../assets/CovidRecoveryCorpsLogo.svg'
 
 const useStyles = makeStyles(theme => ({
   container: {
     width: '100%',
-    height: '800px',
+    height: '900px',
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
@@ -18,11 +18,12 @@ const useStyles = makeStyles(theme => ({
     justifyContent: 'space-between',
     color: 'black',
     width: '170px',
-    marginTop: '-10px',
+    marginTop: '-15px',
   },
   languageText: {
     color: 'black',
     cursor: 'pointer',
+    fontSize: '15px',
   },
   selectedLanguage: {
     fontWeight: 'bold',
@@ -31,9 +32,17 @@ const useStyles = makeStyles(theme => ({
   videoContainer: {
     marginTop: '30px',
   },
+  topBanner: {
+    height: '92px',
+    width: '100%',
+    display: 'flex',
+    justifyContent: 'flex-start',
+    paddingTop: '15px',
+    paddingLeft: '25px',
+  },
 }))
 
-const TestKitInformationScreen: React.FC<Props> = props => {
+const TestKitInformationScreen: React.FC<{}> = props => {
   const [englishIsSelected, setEnglishSelected] = useState<boolean>(true)
   const classes = useStyles()
   const engishTextClasses = [classes.languageText]
@@ -52,6 +61,12 @@ const TestKitInformationScreen: React.FC<Props> = props => {
 
   return (
     <div className={classes.container}>
+      <div className={classes.topBanner}>
+        <NavLink to="/home">
+          <CovidRecoveryCorpsLogo />
+        </NavLink>
+      </div>
+
       <h2>Blood Sample Collection Instructions</h2>
       <div className={classes.languageRow}>
         <div
@@ -68,8 +83,8 @@ const TestKitInformationScreen: React.FC<Props> = props => {
         </div>
       </div>
       <Iframe
-        width="800px"
-        height="500px"
+        width="900px"
+        height="550px"
         url={
           englishIsSelected
             ? 'https://www.youtube.com/embed/--MX5u9a12Y?autoplay=1'

--- a/src/components/static/TestKitInformationScreen.tsx
+++ b/src/components/static/TestKitInformationScreen.tsx
@@ -76,7 +76,9 @@ const TestKitInformationScreen: React.FC<{}> = props => {
           <CovidRecoveryCorpsLogo />
         </NavLink>
       </div>
-      <h2 className={classes.header}>{t('testKitInstructionPage.instructionHeader')}</h2>
+      <h2 className={classes.header}>
+        {t('testKitInstructionPage.instructionHeader')}
+      </h2>
       <div className={classes.languageRow}>
         <button
           className={`${classes.languageButton} ${

--- a/src/components/static/TestKitInformationScreen.tsx
+++ b/src/components/static/TestKitInformationScreen.tsx
@@ -1,15 +1,84 @@
-import React from "react";
+import React, { useState } from 'react'
+import Iframe from 'react-iframe'
+import { makeStyles } from '@material-ui/core'
 
-interface Props {
+interface Props {}
 
-}
+const useStyles = makeStyles(theme => ({
+  container: {
+    width: '100%',
+    height: '800px',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+  },
+  languageRow: {
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    color: 'black',
+    width: '170px',
+    marginTop: '-10px',
+  },
+  languageText: {
+    color: 'black',
+    cursor: 'pointer',
+  },
+  selectedLanguage: {
+    fontWeight: 'bold',
+    textDecoration: 'underline',
+  },
+  videoContainer: {
+    marginTop: '30px',
+  },
+}))
 
-const TestKitInformationScreen : React.FC<Props> = (props) => {
-    return (
-        <div>
-            hello
+const TestKitInformationScreen: React.FC<Props> = props => {
+  const [englishIsSelected, setEnglishSelected] = useState<boolean>(true)
+  const classes = useStyles()
+  const engishTextClasses = [classes.languageText]
+  const spanishTextClasses = [classes.languageText]
+  englishIsSelected
+    ? engishTextClasses.push(classes.selectedLanguage)
+    : spanishTextClasses.push(classes.selectedLanguage)
+
+  const handleLanguagePressed = (pressedLanguage: String) => {
+    if (pressedLanguage === 'ENGLISH' && !englishIsSelected) {
+      setEnglishSelected(true)
+    } else if (pressedLanguage === 'SPANISH' && englishIsSelected) {
+      setEnglishSelected(false)
+    }
+  }
+
+  return (
+    <div className={classes.container}>
+      <h2>Blood Sample Collection Instructions</h2>
+      <div className={classes.languageRow}>
+        <div
+          className={engishTextClasses.join(' ')}
+          onClick={() => handleLanguagePressed('ENGLISH')}
+        >
+          English
         </div>
-    )
+        <div
+          className={spanishTextClasses.join(' ')}
+          onClick={() => handleLanguagePressed('SPANISH')}
+        >
+          en español
+        </div>
+      </div>
+      <Iframe
+        width="800px"
+        height="500px"
+        url={
+          englishIsSelected
+            ? 'https://www.youtube.com/embed/--MX5u9a12Y?autoplay=1'
+            : 'https://www.youtube.com/embed/bM6MoVTAegQ?autoplay=1'
+        }
+        className={classes.videoContainer}
+      />
+    </div>
+  )
 }
 
-export default TestKitInformationScreen;
+export default TestKitInformationScreen

--- a/src/components/static/TestKitInformationScreen.tsx
+++ b/src/components/static/TestKitInformationScreen.tsx
@@ -3,6 +3,7 @@ import { makeStyles } from '@material-ui/core'
 import { NavLink } from 'react-router-dom'
 import { ReactComponent as CovidRecoveryCorpsLogo } from '../../assets/CovidRecoveryCorpsLogo.svg'
 import i18n from '../../i18n'
+import { useTranslation } from 'react-i18next'
 
 const useStyles = makeStyles(theme => ({
   container: {
@@ -56,6 +57,7 @@ const useStyles = makeStyles(theme => ({
 const TestKitInformationScreen: React.FC<{}> = props => {
   const [language, setLanguage] = useState<string>(i18n.language)
   const classes = useStyles()
+  const { t } = useTranslation()
 
   const changeLanguage = (pressedLanguage: string) => {
     if (pressedLanguage !== language) {
@@ -74,11 +76,7 @@ const TestKitInformationScreen: React.FC<{}> = props => {
           <CovidRecoveryCorpsLogo />
         </NavLink>
       </div>
-      <h2 className={classes.header}>{`${
-        language === 'en'
-          ? 'Blood Sample Collection Instructions'
-          : 'Instrucciones para la recolección de muestras de sangre'
-      }`}</h2>
+      <h2 className={classes.header}>{t('testKitInstructionPage.instructionHeader')}</h2>
       <div className={classes.languageRow}>
         <button
           className={`${classes.languageButton} ${

--- a/src/components/static/TestKitInformationScreen.tsx
+++ b/src/components/static/TestKitInformationScreen.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+interface Props {
+
+}
+
+const TestKitInformationScreen : React.FC<Props> = (props) => {
+    return (
+        <div>
+            hello
+        </div>
+    )
+}
+
+export default TestKitInformationScreen;

--- a/src/components/widgets/TopNav.tsx
+++ b/src/components/widgets/TopNav.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { NavLink } from 'react-router-dom'
 import { faBars, faTimes } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -178,12 +178,15 @@ export const TopNav: React.FunctionComponent<TopNavProps> = props => {
     setMobileOpen(!mobileOpen)
   }
 
+  useEffect(() => {
+    setLanguage(i18n.language)
+  }, [i18n.language])
+
   const changeLanguage = () => {
     const newLanguage = i18n.language === 'es' ? 'en' : 'es'
     window.localStorage.setItem('appUILang', newLanguage)
 
     i18n.changeLanguage(newLanguage)
-    setLanguage(newLanguage)
   }
 
   const drawer = (

--- a/src/components/widgets/TopNav.tsx
+++ b/src/components/widgets/TopNav.tsx
@@ -33,6 +33,7 @@ import { Feature, TOGGLE_NAMES } from '../../helpers/FeatureToggle'
 type TopNavProps = {
   token: string | undefined
   logoutCallbackFn: Function
+  showTopNavigator: boolean
 }
 const drawerWidth = 275
 const useStyles = makeStyles(theme => ({
@@ -224,16 +225,16 @@ export const TopNav: React.FunctionComponent<TopNavProps> = props => {
           </ListItem>
         </NavLink>
         {
-        <NavLink
-          to="/learninghub"
-          onClick={handleDrawerToggle}
-          className={classes.navBarLink}
-        >
-          <ListItem button className={classes.mobileMenuItem}>
-            {t('topnav.text31')}
-          </ListItem>
-        </NavLink>
-         }
+          <NavLink
+            to="/learninghub"
+            onClick={handleDrawerToggle}
+            className={classes.navBarLink}
+          >
+            <ListItem button className={classes.mobileMenuItem}>
+              {t('topnav.text31')}
+            </ListItem>
+          </NavLink>
+        }
         <NavLink
           to="/contact"
           onClick={handleDrawerToggle}
@@ -401,7 +402,7 @@ export const TopNav: React.FunctionComponent<TopNavProps> = props => {
         >
           {language === 'es' ? 'in English' : 'en español'}
         </a>
-        </Feature>
+      </Feature>
 
       {props.token && (
         <NavLink
@@ -440,69 +441,77 @@ export const TopNav: React.FunctionComponent<TopNavProps> = props => {
       )}
     </div>
   )
-
   return (
     <div>
-      <CssBaseline />
-      <div className="no-print">
-        <Toolbar className={classes.toolBar}>
-          <div>
-            <Typography variant="h6" noWrap className={classes.navbarTitle}>
-              <NavLink to="/home">
-                <CovidRecoveryCorpsLogo />
-              </NavLink>
-            </Typography>
+      {props.showTopNavigator ? (
+        <div>
+          <CssBaseline />
+          <div className="no-print">
+            <Toolbar className={classes.toolBar}>
+              <div>
+                <Typography variant="h6" noWrap className={classes.navbarTitle}>
+                  <NavLink to="/home">
+                    <CovidRecoveryCorpsLogo />
+                  </NavLink>
+                </Typography>
+              </div>
+
+              {/* show hamburger menu on xs and sm, but full nav bar on md and up */}
+              <Hidden lgUp>
+                <IconButton
+                  color="inherit"
+                  aria-label="Open drawer"
+                  edge="end"
+                  onClick={handleDrawerToggle}
+                  className={classes.menuButton}
+                >
+                  <FontAwesomeIcon icon={faBars}></FontAwesomeIcon>
+                </IconButton>
+              </Hidden>
+              <Hidden mdDown>{fullScreenNavBar}</Hidden>
+            </Toolbar>
           </div>
-
-          {/* show hamburger menu on xs and sm, but full nav bar on md and up */}
-          <Hidden lgUp>
-            <IconButton
-              color="inherit"
-              aria-label="Open drawer"
-              edge="end"
-              onClick={handleDrawerToggle}
-              className={classes.menuButton}
+          <nav className={classes.drawer}>
+            <Drawer
+              variant="temporary"
+              anchor="right"
+              open={mobileOpen}
+              onClose={handleDrawerToggle}
+              classes={{
+                paper: classes.drawerPaper,
+              }}
+              ModalProps={{
+                keepMounted: true, // Better open performance on mobile.
+              }}
             >
-              <FontAwesomeIcon icon={faBars}></FontAwesomeIcon>
-            </IconButton>
-          </Hidden>
-          <Hidden mdDown>{fullScreenNavBar}</Hidden>
-        </Toolbar>
-      </div>
-
-      <nav className={classes.drawer}>
-        <Drawer
-          variant="temporary"
-          anchor="right"
-          open={mobileOpen}
-          onClose={handleDrawerToggle}
-          classes={{
-            paper: classes.drawerPaper,
-          }}
-          ModalProps={{
-            keepMounted: true, // Better open performance on mobile.
-          }}
-        >
-          {drawer}
-        </Drawer>
-      </nav>
-
-      {/* global alert area */}
-      {alertCode && !isGlobalNotificationAlertHiddenFlag && (
-        <Alert
-          severity="error"
-          variant="filled"
-          icon={false}
-          classes={{
-            message: classes.globalAlertMessage,
-          }}
-        >
-          <Grid container direction="row" justify="center" alignItems="center">
-            <GlobalAlertCopy code={alertCode}></GlobalAlertCopy>
-          </Grid>
-        </Alert>
+              {drawer}
+            </Drawer>
+          </nav>
+          {/* global alert area */}
+          {alertCode && !isGlobalNotificationAlertHiddenFlag && (
+            <Alert
+              severity="error"
+              variant="filled"
+              icon={false}
+              classes={{
+                message: classes.globalAlertMessage,
+              }}
+            >
+              <Grid
+                container
+                direction="row"
+                justify="center"
+                alignItems="center"
+              >
+                <GlobalAlertCopy code={alertCode}></GlobalAlertCopy>
+              </Grid>
+            </Alert>
+          )}
+          <div className={classes.content}>{props.children}</div>
+        </div>
+      ) : (
+        <div className={classes.content}>{props.children}</div>
       )}
-      <div className={classes.content}>{props.children}</div>
     </div>
   )
 }


### PR DESCRIPTION
Created a new page with path "/testkit" that displays a video to the user about home kit paper instructions.

The page looks as follows:
![image](https://user-images.githubusercontent.com/31671708/104664117-50215b80-5683-11eb-8d03-42c31af80d98.png)

Resolves #732
